### PR TITLE
conf: intercom to http

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -13,7 +13,7 @@ resource "google_compute_global_address" "main" {
 
 resource "google_compute_backend_service" "main" {
   name     = "intercom"
-  protocol = "HTTPS"
+  protocol = var.backend_service_protocol
   backend {
     group = google_compute_global_network_endpoint_group.main.id
   }

--- a/dns.tf
+++ b/dns.tf
@@ -3,6 +3,7 @@ resource "google_dns_record_set" "main" {
   managed_zone = data.google_dns_managed_zone.main[0].name
   name         = "${var.dns_name}."
   type         = "A"
+  ttl          = "300"
 
   rrdatas = [google_compute_global_address.main.address]
 }

--- a/neg.tf
+++ b/neg.tf
@@ -1,11 +1,11 @@
 resource "google_compute_global_network_endpoint_group" "main" {
   name                  = "intercom"
-  default_port          = 433
+  default_port          = var.intercom_port
   network_endpoint_type = "INTERNET_FQDN_PORT"
 }
 
 resource "google_compute_global_network_endpoint" "main" {
   global_network_endpoint_group = google_compute_global_network_endpoint_group.main.id
-  port                          = 433
+  port                          = var.intercom_port
   fqdn                          = var.intercom_fqdn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,15 @@ variable "intercom_fqdn" {
   default     = "custom.intercom.help"
   description = "Domain of the intercom server"
 }
+
+variable "intercom_port" {
+  type        = number
+  default     = 80
+  description = "Port to reach Intercom with"
+}
+
+variable "backend_service_protocol" {
+  type        = string
+  default     = "HTTP"
+  description = "Protocol for backend service"
+}


### PR DESCRIPTION
As HTTPS procotol returns 502 now, changing it over to HTTP for communication between GCP and Intercom.