### PR TITLE
Add second load balancer for http to https redirect

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -22,10 +22,6 @@ resource "google_compute_backend_service" "main" {
 resource "google_compute_url_map" "main" {
   name            = "intercom"
   default_service = google_compute_backend_service.main.id
-  default_url_redirect {
-    https_redirect = true
-    strip_query    = false
-  }
 }
 
 resource "google_compute_target_https_proxy" "main" {
@@ -41,4 +37,25 @@ resource "google_compute_global_forwarding_rule" "main" {
   load_balancing_scheme = "EXTERNAL"
   target                = google_compute_target_https_proxy.main.id
   port_range            = 443
+}
+
+resource "google_compute_url_map" "http-redirect" {
+  name = "http-redirect"
+
+  default_url_redirect {
+    strip_query            = false
+    https_redirect         = true
+  }
+}
+
+resource "google_compute_target_http_proxy" "http-redirect" {
+  name    = "http-redirect"
+  url_map = google_compute_url_map.http-redirect.self_link
+}
+
+resource "google_compute_global_forwarding_rule" "http-redirect" {
+  name       = "http-redirect"
+  target     = google_compute_target_http_proxy.http-redirect.self_link
+  ip_address = google_compute_global_address.main.address
+  port_range = "80"
 }


### PR DESCRIPTION
The latest version (1.0.3) did not work for me. I got an error:

```
│ Error: ExactlyOne
│ 
│   with module.intercom.google_compute_url_map.main,
│   on .terraform/modules/intercom/compute.tf line 22, in resource "google_compute_url_map" "main":
│   22: resource "google_compute_url_map" "main" {
│ 
│ "default_url_redirect": only one of 'default_route_action.0.weighted_backend_services,default_service,default_url_redirect' can be specified, but
│ 'default_service,default_url_redirect' were specified.
```

This PR instead adds a second load balancer without backend but with forwarding rule that redirects http to https.

Verified that this code works on our current Intercom help center setup