### PR TITLE
Add option for HSTS headers

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -12,8 +12,12 @@ resource "google_compute_global_address" "main" {
 }
 
 resource "google_compute_backend_service" "main" {
-  name     = "intercom"
-  protocol = var.backend_service_protocol
+  name                    = "intercom"
+  protocol                = var.backend_service_protocol
+  custom_response_headers = var.enable_hsts ? [
+    "Strict-Transport-Security:max-age=31536000; includeSubDomains"
+  ] : []
+
   backend {
     group = google_compute_global_network_endpoint_group.main.id
   }

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,9 @@ variable "backend_service_protocol" {
   default     = "HTTP"
   description = "Protocol for backend service"
 }
+
+variable "enable_hsts" {
+  type        = bool
+  default     = false
+  description = "Sets a Strict-Transport-Security header"
+}


### PR DESCRIPTION
This PR adds the option to enable HTTP Strict Transport Security (HSTS) headers on the response. This is missing when using a custom domain https://community.intercom.com/settings-security-permissions-22/missing-header-strict-transport-security-3984

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service#example-usage---backend-service-network-endpoint

This requires a google provider [3.73.0](https://github.com/hashicorp/terraform-provider-google/releases/tag/v3.73.0) or newer.